### PR TITLE
fix typo in pandoc-viewers

### DIFF
--- a/pandoc-mode-utils.el
+++ b/pandoc-mode-utils.el
@@ -360,7 +360,7 @@ possible to customize the extensions."
     ("muse"              emacs)
     ("native"            emacs)
     ("odt"               "libreoffice")
-    ("opendocument"      "liberoffice")
+    ("opendocument"      "libreoffice")
     ("opml"              nil)
     ("org"               emacs)
     ("plain"             emacs)


### PR DESCRIPTION
liberoffice is assumed to be a typo of libreoffice, which is used to open documents. Not sure anyone has hit this bug though.